### PR TITLE
[NO-ISSUE] Allow pso-db-runner role to pod exec

### DIFF
--- a/pureStorageDriver/templates/database/rbac.yaml
+++ b/pureStorageDriver/templates/database/rbac.yaml
@@ -22,6 +22,11 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs: ["create"]
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get


### PR DESCRIPTION
This allows the cockroach-operator to run decommission commands.