### PR TITLE
[NO-ISSUE] Removed Helm hook from cert secrets

### DIFF
--- a/pureStorageDriver/templates/database/cert-secret.yaml
+++ b/pureStorageDriver/templates/database/cert-secret.yaml
@@ -13,9 +13,6 @@ metadata:
         chart: {{ template "pure-csi.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-    annotations:
-        "helm.sh/hook": "pre-install"
-        "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
     ca.crt: {{ b64enc $ca.Cert }}
     node.crt: {{ b64enc $node.Cert }}
@@ -34,9 +31,6 @@ metadata:
         chart: {{ template "pure-csi.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-    annotations:
-        "helm.sh/hook": "pre-install"
-        "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
     ca.crt: {{ b64enc $ca.Cert }}
     client.root.crt: {{ b64enc $client.Cert }}


### PR DESCRIPTION
This fixes these certificates not being cleaned up by a `helm del`. My guess is that these annotations were included when we used Helm 2 which might have treated secrets differently. Regardless, I tested with a manual uninstall and everything worked as expected.