### PR TITLE
[NO-ISSUE] Fixed cockroach-operator watch RBAC

### DIFF
--- a/pureStorageDriver/templates/database/rbac.yaml
+++ b/pureStorageDriver/templates/database/rbac.yaml
@@ -76,7 +76,7 @@ rules:
     - serviceaccounts
     - roles
     - rolebindings
-  verbs: ["list"]
+  verbs: ["list", "watch"]
 
 # Updating of ServiceAccounts
 - apiGroups:


### PR DESCRIPTION
Previously, cockroach-operator would sometimes throw errors on API server restarts, saying that it couldn't watch ServiceAccounts, Roles, and RoleBindings. We don't do any watches from cockroach-operator on them, but my guess is that when we set owner references it adds a watch (which is set up automatically at the beginning, but might need a refresh on API server restarts).