### PR TITLE
Revert "[NO-ISSUE] Removed Helm hook from cert secrets"

### DIFF
--- a/pureStorageDriver/templates/database/cert-secret.yaml
+++ b/pureStorageDriver/templates/database/cert-secret.yaml
@@ -13,6 +13,9 @@ metadata:
         chart: {{ template "pure-csi.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+    annotations:
+        "helm.sh/hook": "pre-install"
+        "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
     ca.crt: {{ b64enc $ca.Cert }}
     node.crt: {{ b64enc $node.Cert }}
@@ -31,6 +34,9 @@ metadata:
         chart: {{ template "pure-csi.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+    annotations:
+        "helm.sh/hook": "pre-install"
+        "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
     ca.crt: {{ b64enc $ca.Cert }}
     client.root.crt: {{ b64enc $client.Cert }}


### PR DESCRIPTION
Turns out that, while this worked great for initial installs and `helm delete`s, it breaks on upgrades. I'm developing an alternative, code-based solution.