### PR TITLE
[ISSUE-40] Added extra RBAC to match stricter OSE requirements

### DIFF
--- a/pureStorageDriver/templates/database/rbac.yaml
+++ b/pureStorageDriver/templates/database/rbac.yaml
@@ -22,6 +22,11 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets/finalizers
+  verbs: ["update"]
+- apiGroups:
+  - ""
+  resources:
   - pods/exec
   verbs: ["create"]
 - apiGroups:
@@ -83,21 +88,21 @@ rules:
     - ""
   resources:
     - serviceaccounts
-  verbs: ["get", "update"]
+  verbs: ["get", "update", "delete"]
   resourceNames:
     - {{ .Values.clusterrolebinding.serviceAccount.name }}
 - apiGroups:
     - rbac.authorization.k8s.io
   resources:
     - roles
-  verbs: ["get", "update"]
+  verbs: ["get", "update", "delete"]
   resourceNames:
     - pso-db-runner
 - apiGroups:
     - rbac.authorization.k8s.io
   resources:
     - rolebindings
-  verbs: ["get", "update"]
+  verbs: ["get", "update", "delete"]
   resourceNames:
     - pso-db-role
 ---

--- a/pureStorageDriver/templates/plugin/scc.yaml
+++ b/pureStorageDriver/templates/plugin/scc.yaml
@@ -1,0 +1,34 @@
+{{- if eq .Values.orchestrator.name "openshift"}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: pso-scc
+
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: null
+
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.clusterrolebinding.serviceAccount.name }}
+volumes:
+  # Allow all volume types (we specifically use hostPath and secrets)
+  - '*'
+{{- end}}

--- a/pureStorageDriver/values.schema.json
+++ b/pureStorageDriver/values.schema.json
@@ -1682,6 +1682,7 @@
                 "name": {
                     "$id": "#/properties/orchestrator/properties/name",
                     "type": "string",
+                    "enum": ["k8s", "openshift"],
                     "title": "The name schema",
                     "default": "",
                     "examples": [


### PR DESCRIPTION
Adds a SecurityContextConstraints object for when `Values.plugin.orchestrator` is set to `openshift`. Also fleshes out the values schema to restrict this value to either `k8s` or `openshift`.

Also updates our existing RBAC objects with the following changes:
* Allows updating of secret finalizers
* Allows deletion of our ServiceAccount, Role, and RoleBinding

This has not yet been tested on a physical OpenShift cluster, and more debugging work is being done. Mainly opening this PR for visibility and ease of testing (@sdodsley once you get a chance), it will likely require more edits as time goes on.

Addresses #40.