### PR TITLE
[NO-ISSUE] Delete useless k8s version checks

### DIFF
--- a/pureStorageDriver/templates/plugin/controller-server.yaml
+++ b/pureStorageDriver/templates/plugin/controller-server.yaml
@@ -139,8 +139,6 @@ spec:
               mountPath: /csi
 # The csi-resizer sidecar that watches the Kubernetes API server for PersistentVolumeClaim updates.
 # Does not scale with more replicas, only one is elected as leader and running.
-# PSO requires K8s 1.16+ for CSI VolumeExpansion
-{{ if and (eq .Capabilities.KubeVersion.Major "1") (gt .Capabilities.KubeVersion.Minor "15") }}
         - name: csi-resizer
           {{- with .Values.images.csi.resizer }}
           image: {{ .name | default "quay.io/k8scsi/csi-resizer" }}:v0.5.0
@@ -153,22 +151,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-{{ end }}
-# This is the cluster-driver-registrar sidecar that allows helm-install without CRD-hooks for the CSIDriver CRD
-# The reason we do not want a crd-hook with helm-chart is to avoid upgrade issues like: https://github.com/helm/helm/issues/4489
-{{ if and (eq .Capabilities.KubeVersion.Major "1") (eq .Capabilities.KubeVersion.Minor "13") }}
-        - name: cluster-driver-registrar
-          {{- with .Values.images.csi.clusterDriverRegistrar }}
-          image: {{ .name | default "quay.io/k8scsi/csi-cluster-driver-registrar" }}:v1.0.1
-          imagePullPolicy: {{ .pullPolicy }}
-          {{- end }}
-          args:
-            - "--csi-address=/csi/csi.sock"
-            - "--driver-requires-attachment=true"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-{{ end }}
         - name: liveness-probe
           volumeMounts:
           - mountPath: /csi

--- a/pureStorageDriver/templates/plugin/node-server.yaml
+++ b/pureStorageDriver/templates/plugin/node-server.yaml
@@ -1,56 +1,9 @@
-# On K8s 1.12 and 1.13 you need to create this CRD on the cluster before the helm install. 
-# This is because CSI is still alpha on these versions and the CSIDriver object is a CRD. 
-# Our helm chart cannot create this CRD because if affects other CSI-drivers that may be installed 
-# on the cluster. 
-# See https://kubernetes-csi.github.io/docs/csi-driver-object.html for details.
-# Inlining the CRD definition here in comments if you want to copy and apply.
-#
-# {{ if and (eq .Capabilities.KubeVersion.Major "1") (lt .Capabilities.KubeVersion.Minor "14") }}
-# apiVersion: apiextensions.k8s.io/v1beta1
-# kind: CustomResourceDefinition
-# metadata:
-#  name: csidrivers.csi.storage.k8s.io
-#  labels:
-#    addonmanager.kubernetes.io/mode: Reconcile
-# spec:
-#  group: csi.storage.k8s.io
-#  names:
-#    kind: CSIDriver
-#    plural: csidrivers
-#  scope: Cluster
-#  validation:
-#    openAPIV3Schema:
-#      properties:
-#        spec:
-#          description: Specification of the CSI Driver.
-#          properties:
-#            attachRequired:
-#              description: Indicates this CSI volume driver requires an attach operation,
-#                and that Kubernetes should call attach and wait for any attach operation
-#                to complete before proceeding to mount.
-#              type: boolean
-#            podInfoOnMountVersion:
-#              description: Indicates this CSI volume driver requires additional pod
-#                information (like podName, podUID, etc.) during mount operations.
-#              type: string
-#  version: v1alpha1
-# {{ end }}
----
-{{ if and (eq .Capabilities.KubeVersion.Major "1") (gt .Capabilities.KubeVersion.Minor "13") }}
-# For Kubernetes v1.13, this is not needed, because
-# we should be using cluster-driver-registrar sidecar
-# container.
-# For v1.14, this object needs to be created manually.
-# When controller-attach-detach comes in, we will start
-# using the controller sidecar, and we can delete
-# this object.
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: pure-csi
 spec:
   attachRequired: true
-{{ end }}
 ---
 kind: DaemonSet
 apiVersion: {{ template "daemonset.apiVersion" . }}

--- a/pureStorageDriver/templates/plugin/rbac.yaml
+++ b/pureStorageDriver/templates/plugin/rbac.yaml
@@ -154,72 +154,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 
-{{ if and (eq .Capabilities.KubeVersion.Major "1") (eq .Capabilities.KubeVersion.Minor "13") }}
-# This file is downloaded from https://github.com/kubernetes-csi/cluster-driver-registrar/archive/v1.0.1.tar.gz 
-# NOTE: this repo is only for Kubernetes versions 1.12 and 1.13. The rbac in the master branch is not maintained so use the
-# one in the released branch.
-
-# This YAML file contains all RBAC objects that are necessary to run cluster-driver-registrar sidecar because our
-# CSI driver does not yet support ControllerPublish/Unpublish and we need the 'SkipAttach' functionality.
-# Also this sidecar is not being used in 1.14 so this is only for 1.13 right now. 
-# NOTE: Kubernetes 1.12 needs a different sidecar : https://github.com/kubernetes-csi/driver-registrar.
-#
-# In production, each CSI driver deployment has to be customized:
-# - to avoid conflicts, use non-default namespace and different names
-#   for non-namespaced entities like the ClusterRole
-# - decide whether the deployment replicates the external CSI
-#   provisioner, in which case leadership election must be enabled;
-#   this influences the RBAC setup, see below
-
-kind: ClusterRole
-apiVersion: {{ template "rbac.apiVersion" . }}
-metadata:
-  name: driver-registrar-runner
-  labels:
-{{ include "pure-csi.labels" . | indent 4}}
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-  # The following permissions are only needed when running
-  # driver-registrar without the --kubelet-registration-path
-  # parameter, i.e. when using driver-registrar instead of
-  # kubelet to update the csi.volume.kubernetes.io/nodeid
-  # annotation. That mode of operation is going to be deprecated
-  # and should not be used anymore, but is needed on older
-  # Kubernetes versions.
-  # - apiGroups: [""]
-  #   resources: ["nodes"]
-  #   verbs: ["get", "update", "patch"]
-  # ** This is needed for helm to Install the CRD for CSIDriver
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ['*']
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ['*']
----
-kind: ClusterRoleBinding
-apiVersion: {{ template "rbac.apiVersion" . }}
-metadata:
-  name: csi-driver-registrar-role
-  labels:
-{{ include "pure-csi.labels" . | indent 4}}
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Values.clusterrolebinding.serviceAccount.name }}
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: driver-registrar-runner
-  apiGroup: rbac.authorization.k8s.io
-
-{{ end }}
-
-{{ if and (eq .Capabilities.KubeVersion.Major "1") (gt .Capabilities.KubeVersion.Minor "15") }}
-# PSO requires K8s 1.16+ for CSI VolumeExpansion
 # This file is downloaded from https://github.com/kubernetes-csi/external-resizer/blob/master/deploy/kubernetes/rbac.yaml
----
 kind: ClusterRole
 apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
@@ -260,4 +195,3 @@ roleRef:
   kind: ClusterRole
   name: external-resizer-runner
   apiGroup: rbac.authorization.k8s.io
-{{ end }}

--- a/pureStorageDriver/templates/plugin/storage-class.yaml
+++ b/pureStorageDriver/templates/plugin/storage-class.yaml
@@ -8,10 +8,7 @@ metadata:
 provisioner: pure-csi # This must match the name of the CSIDriver. And the name of the CSI plugin from the RPC 'GetPluginInfo'
 parameters:
     backend: file
-# PSO requires K8s 1.16+ for CSI VolumeExpansion
-{{ if and (eq .Capabilities.KubeVersion.Major "1") (gt .Capabilities.KubeVersion.Minor "15") }}
 allowVolumeExpansion: true
-{{ end }}
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -27,10 +24,7 @@ parameters:
   backend: block
   csi.storage.k8s.io/fstype: xfs
   createoptions: {{ .Values.flasharray.defaultFSOpt | default "-q" | quote }}
-# PSO requires K8s 1.16+ for CSI VolumeExpansion
-{{ if and (eq .Capabilities.KubeVersion.Major "1") (gt .Capabilities.KubeVersion.Minor "15") }}
 allowVolumeExpansion: true
-{{ end }}
 # support either string or list for .Values.flasharray.defaultMountOpt
 {{- if or (kindIs "array" .Values.flasharray.defaultMountOpt) (kindIs "slice" .Values.flasharray.defaultMountOpt) }}
 mountOptions:


### PR DESCRIPTION
* since PSO 6.0+ require k8s 1.17+, some k8s version checks are no longer needed.