### PR TITLE
[ISSUE-40] Added more missing OpenShift security objects

### DIFF
--- a/pureStorageDriver/templates/database/cockroach-operator.yaml
+++ b/pureStorageDriver/templates/database/cockroach-operator.yaml
@@ -33,6 +33,10 @@ spec:
               value: pso-db-role
             - name: SECRET_NAMES
               value: pso-cockroach-node-certs,pso-cockroach-client-certs
+{{ - if eq .Values.orchestrator.name "openshift" }}
+            - name: SCC_NAME
+              value: pso-scc
+{{ - end }}
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/pureStorageDriver/templates/plugin/rbac.yaml
+++ b/pureStorageDriver/templates/plugin/rbac.yaml
@@ -160,7 +160,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: external-resizer-runner
   labels:
-{{ include "pure-csi.labels" . | indent 4}}
+{{ include "pure-csi.labels" . | indent 4 }}
 rules:
   # The following rule should be uncommented for plugins that require secrets
   # for provisioning.
@@ -186,7 +186,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: csi-resizer-role
   labels:
-{{ include "pure-csi.labels" . | indent 4}}
+{{ include "pure-csi.labels" . | indent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.clusterrolebinding.serviceAccount.name }}
@@ -195,3 +195,44 @@ roleRef:
   kind: ClusterRole
   name: external-resizer-runner
   apiGroup: rbac.authorization.k8s.io
+
+---
+# Updating of pso-scc SecurityContextConstraints (if OpenShift)
+{{ - if eq .Values.orchestrator.name "openshift" }}
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: pso-scc-owner
+  labels:
+{{ include "pure-csi.labels" . | indent 4 }}
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs: ["get", "watch", "update", "patch", "delete"]
+    resourceNames:
+      - pso-scc
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs: ["list"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: pso-scc-owner-role
+  labels:
+{{ include "pure-csi.labels" . | indent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.clusterrolebinding.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: pso-scc-owner
+  apiGroup: rbac.authorization.k8s.io
+
+{{ - end }}

--- a/pureStorageDriver/templates/plugin/scc.yaml
+++ b/pureStorageDriver/templates/plugin/scc.yaml
@@ -1,8 +1,10 @@
-{{- if eq .Values.orchestrator.name "openshift"}}
+{{ - if eq .Values.orchestrator.name "openshift" }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: pso-scc
+  annotations:
+    "helm.sh/resource-policy": keep  # THIS IS IMPORTANT: it's what allows the cockroach operator to clean itself up
 
 allowHostDirVolumePlugin: true
 allowHostIPC: false
@@ -31,4 +33,4 @@ users:
 volumes:
   # Allow all volume types (we specifically use hostPath and secrets)
   - '*'
-{{- end}}
+{{ - end }}


### PR DESCRIPTION
Adds a few things I missed from before:
* Adds an SCC name variable to the cockroach-operator for OpenShift deployments only
* Adds the necessary ClusterRole and ClusterRoleBinding to allow cockroach-operator to own the SCC
* Makes the SCC not get removed with `helm del`