### PR TITLE
[ISSUE-55] Enables setting export rules for database volumes

### DIFF
--- a/pureStorageDriver/templates/database/cockroach-operator.yaml
+++ b/pureStorageDriver/templates/database/cockroach-operator.yaml
@@ -33,10 +33,10 @@ spec:
               value: pso-db-role
             - name: SECRET_NAMES
               value: pso-cockroach-node-certs,pso-cockroach-client-certs
-{{ - if eq .Values.orchestrator.name "openshift" }}
+{{- if eq .Values.orchestrator.name "openshift" }}
             - name: SCC_NAME
               value: pso-scc
-{{ - end }}
+{{- end }}
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/pureStorageDriver/templates/database/db-deployer.yaml
+++ b/pureStorageDriver/templates/database/db-deployer.yaml
@@ -21,6 +21,9 @@ spec:
           image: "{{ .Values.images.database.deployer.name }}:{{ .Values.images.database.deployer.tag }}"
           command:
           - dbdeployer
+          volumeMounts:
+          - name: configmap-volume
+            mountPath: /etc/config
           imagePullPolicy: "{{ .Values.images.database.deployer.pullPolicy }}"
           env:
             - name: WATCH_NAMESPACE
@@ -33,6 +36,10 @@ spec:
                   fieldPath: metadata.name
             - name: PURE_K8S_NAMESPACE
               value: {{ .Values.clusterID }}
+      volumes:
+      - name: configmap-volume
+        configMap:
+          name: pure-csi-container-configmap
       {{- with .Values.database.nodeSelector | default .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/pureStorageDriver/templates/plugin/rbac.yaml
+++ b/pureStorageDriver/templates/plugin/rbac.yaml
@@ -198,7 +198,7 @@ roleRef:
 
 ---
 # Updating of pso-scc SecurityContextConstraints (if OpenShift)
-{{ - if eq .Values.orchestrator.name "openshift" }}
+{{- if eq .Values.orchestrator.name "openshift" }}
 kind: ClusterRole
 apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
@@ -235,4 +235,4 @@ roleRef:
   name: pso-scc-owner
   apiGroup: rbac.authorization.k8s.io
 
-{{ - end }}
+{{- end }}

--- a/pureStorageDriver/templates/plugin/scc.yaml
+++ b/pureStorageDriver/templates/plugin/scc.yaml
@@ -1,4 +1,4 @@
-{{ - if eq .Values.orchestrator.name "openshift" }}
+{{- if eq .Values.orchestrator.name "openshift" }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
@@ -33,4 +33,4 @@ users:
 volumes:
   # Allow all volume types (we specifically use hostPath and secrets)
   - '*'
-{{ - end }}
+{{- end }}


### PR DESCRIPTION
Mounts the PSO ConfigMap into the db-deployer, enabling it to use the configmap settings in database volumes.

Also fixes a formatting error from the last PR.

Closes #55.