### PR TITLE
[NO-ISSUE] RBAC fixes for OSE 4.5

### DIFF
--- a/pureStorageDriver/templates/database/cockroach-operator.yaml
+++ b/pureStorageDriver/templates/database/cockroach-operator.yaml
@@ -55,6 +55,8 @@ spec:
               value: {{ .Values.clusterID }}
             - name: PURE_FLASHARRAY_SAN_TYPE
               value: {{ .Values.flasharray.sanType }}
+          securityContext:
+            privileged: true
           volumeMounts:
             - name: certs
               mountPath: /cockroach/cockroach-certs

--- a/pureStorageDriver/templates/database/rbac.yaml
+++ b/pureStorageDriver/templates/database/rbac.yaml
@@ -8,103 +8,57 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep  # THIS IS IMPORTANT: it's what allows the cockroach operator to clean itself up
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
+- apiGroups: [""]
+  resources: ["pods", "services", "endpoints", "persistentvolumeclaims", "events", "configmaps", "secrets"]
   verbs: ["create", "list", "watch", "delete", "get", "update"]
-- apiGroups:
-  - ""
-  resources:
-  - secrets/finalizers
+- apiGroups: [""]
+  resources: ["secrets/finalizers"]
   verbs: ["update"]
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
+- apiGroups: [""]
+  resources: ["pods/exec"]
   verbs: ["create"]
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "daemonsets", "replicasets", "statefulsets"]
   verbs: ["create", "list", "watch", "delete", "get", "update"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
+- apiGroups: ["batch"]
+  resources: ["jobs"]
   verbs: ["create", "list", "watch", "delete", "get", "update"]
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - pso-db-deployer
-  - pso-cockroach-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - pso.purestorage.com
-  resources:
-  - '*'
+- apiGroups: ["monitoring.coreos.com"]
+  resources: ["servicemonitors"]
+  verbs: ["get", "create"]
+- apiGroups: ["apps"]
+  resourceNames: ["pso-db-deployer", "pso-cockroach-operator"]
+  resources: ["deployments/finalizers"]
+  verbs: ["update"]
+- apiGroups: ["pso.purestorage.com"]
+  resources: ["*"]
   verbs: ["create", "list", "watch", "delete", "get", "update"]
 
 # Post-delete RBAC cleanup stuff: whatever MUST remain around after helm delete should be added here so our pods can
 # clean it up right before cleaning up themselves
 
 # Enable listing of all necessary RBAC resources
-- apiGroups:
-    - ""  # ServiceAccounts
-    - rbac.authorization.k8s.io  # Roles and RoleBindings
-  resources:
-    - serviceaccounts
-    - roles
-    - rolebindings
+- apiGroups: ["", "rbac.authorization.k8s.io"]
+  resources: ["serviceaccounts", "roles", "rolebindings"]
   verbs: ["list", "watch"]
 
 # Updating of ServiceAccounts
-- apiGroups:
-    - ""
-  resources:
-    - serviceaccounts
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
   verbs: ["get", "update", "delete"]
   resourceNames:
     - {{ .Values.clusterrolebinding.serviceAccount.name }}
-- apiGroups:
-    - rbac.authorization.k8s.io
-  resources:
-    - roles
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles"]
   verbs: ["get", "update", "delete"]
-  resourceNames:
-    - pso-db-runner
-- apiGroups:
-    - rbac.authorization.k8s.io
-  resources:
-    - rolebindings
+  resourceNames: ["pso-db-runner"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings"]
   verbs: ["get", "update", "delete"]
-  resourceNames:
-    - pso-db-role
+  resourceNames: ["pso-db-role"]
 ---
 
 kind: RoleBinding

--- a/pureStorageDriver/templates/plugin/rbac.yaml
+++ b/pureStorageDriver/templates/plugin/rbac.yaml
@@ -210,14 +210,14 @@ rules:
       - security.openshift.io
     resources:
       - securitycontextconstraints
-    verbs: ["get", "watch", "update", "patch", "delete"]
+    verbs: ["get", "update", "patch", "delete"]
     resourceNames:
       - pso-scc
   - apiGroups:
       - security.openshift.io
     resources:
       - securitycontextconstraints
-    verbs: ["list"]
+    verbs: ["list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/pureStorageDriver/templates/plugin/rbac.yaml
+++ b/pureStorageDriver/templates/plugin/rbac.yaml
@@ -206,17 +206,12 @@ metadata:
   labels:
 {{ include "pure-csi.labels" . | indent 4 }}
 rules:
-  - apiGroups:
-      - security.openshift.io
-    resources:
-      - securitycontextconstraints
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
     verbs: ["get", "update", "patch", "delete"]
-    resourceNames:
-      - pso-scc
-  - apiGroups:
-      - security.openshift.io
-    resources:
-      - securitycontextconstraints
+    resourceNames: ["pso-scc"]
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
     verbs: ["list", "watch"]
 
 ---


### PR DESCRIPTION
* Makes the cockroach-operator pod privileged to be able to read the cert secrets as root (previous functionality "worked" but couldn't check the DB for health metrics)
* Changed `SecurityContextConstraint` RBAC so all SCCs can be watched, not just `pso-scc`
* Reformatted so that all RBAC files have the same list format (some were using array notation, some were using "hyphen list" notation)