### PR TITLE
[NO-ISSUE] Added the k8s namespace to the controller server

### DIFF
--- a/pure-pso/templates/plugin/controller-server.yaml
+++ b/pure-pso/templates/plugin/controller-server.yaml
@@ -60,6 +60,11 @@ spec:
             - name: configmap-volume
               mountPath: /etc/config
           env:
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
           - name: CSI_ENDPOINT
             value: unix:///csi/csi.sock
           - name: PURE_DISCOVERY_CONF


### PR DESCRIPTION
This is necessary for the DB reconstructor to find itself and all of the relevant nodes.

Not a blocker for GA.