### PR TITLE
Add pre-reqs for OpenShift

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Some of these requirements have changed since PSO 5.x, and not following them _w
   - Minimum Helm version required is 3.1.0.
   - Amazon EKS 1.17.6
   - OpenShift 4.4+
+    - [Note: Please read and action these pre-requisites for OpenShift deployments](docs/openshift_mc.md)
 - #### Other software dependencies for all cluster nodes:
   - Latest linux multipath software package for your operating system (Required) [Note: Multipath on Amazon EKS](docs/eks-multipathd-fix.md)
   - Latest Filesystem utilities/drivers (XFS by default, Required)

--- a/docs/99-pure-storage-attach.yaml
+++ b/docs/99-pure-storage-attach.yaml
@@ -1,0 +1,30 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-pure-storage-attach
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - path: /etc/multipath.conf
+        mode: 384
+        filesystem: root
+        contents:
+        source: data:,defaults%20%7b%0a%20%20%20%20%20%20%20polling_interval%20%20%20%20%20%2010%0a%7d%0adevices%20%7b%0a%20%20device%20%7b%0a%20%20%20%20%20%20%20%20vendor%20%22PURE%22%0a%20%20%20%20%20%20%20%20product%20%22FlashArray%22%0a%20%20%20%20%20%20%20%20fast_io_fail_tmo%2010%0a%20%20%20%20%20%20%20%20path_grouping_policy%20%22group_by_prio%22%0a%20%20%20%20%20%20%20%20failback%20%22immediate%22%0a%20%20%20%20%20%20%20%20prio%20%22alua%22%0a%20%20%20%20%20%20%20%20hardware_handler%20%221%20alua%22%0a%20%20%20%20%20%20%20%20max_sectors_kb%204096%0a%20%20%20%20%7d%0a%7d
+          verification: {}
+      - path: /etc/udev/rules.d/99-pure-storage.rules
+        mode: 420
+        filesystem: root
+        contents:
+          source: data:,%23%20Recommended%20settings%20for%20Pure%20Storage%20FlashArray.%0a%23%20Use%20noop%20scheduler%20for%20high-performance%20solid-state%20storage%20for%20SCSI%20devices%0aACTION%3d%3d%22add%7cchange%22%2c%20KERNEL%3d%3d%22sd%2a%5b%210-9%5d%22%2c%20SUBSYSTEM%3d%3d%22block%22%2c%20ENV%7bID_VENDOR%7d%3d%3d%22PURE%22%2c%20ATTR%7bqueue%2fscheduler%7d%3d%22none%22%0aACTION%3d%3d%22add%7cchange%22%2c%20KERNEL%3d%3d%22dm-%5b0-9%5d%2a%22%2c%20SUBSYSTEM%3d%3d%22block%22%2c%20ENV%7bDM_NAME%7d%3d%3d%223624a937%2a%22%2c%20ATTR%7bqueue%2fscheduler%7d%3d%22none%22%0a%0a%23%20Reduce%20CPU%20overhead%20due%20to%20entropy%20collection%0aACTION%3d%3d%22add%7cchange%22%2c%20KERNEL%3d%3d%22sd%2a%5b%210-9%5d%22%2c%20SUBSYSTEM%3d%3d%22block%22%2c%20ENV%7bID_VENDOR%7d%3d%3d%22PURE%22%2c%20ATTR%7bqueue%2fadd_random%7d%3d%220%22%0aACTION%3d%3d%22add%7cchange%22%2c%20KERNEL%3d%3d%22dm-%5b0-9%5d%2a%22%2c%20SUBSYSTEM%3d%3d%22block%22%2c%20ENV%7bDM_NAME%7d%3d%3d%223624a937%2a%22%2c%20ATTR%7bqueue%2fadd_random%7d%3d%220%22%0a%0a%23%20Spread%20CPU%20load%20by%20redirecting%20completions%20to%20originating%20CPU%0aACTION%3d%3d%22add%7cchange%22%2c%20KERNEL%3d%3d%22sd%2a%5b%210-9%5d%22%2c%20SUBSYSTEM%3d%3d%22block%22%2c%20ENV%7bID_VENDOR%7d%3d%3d%22PURE%22%2c%20ATTR%7bqueue%2frq_affinity%7d%3d%222%22%0aACTION%3d%3d%22add%7cchange%22%2c%20KERNEL%3d%3d%22dm-%5b0-9%5d%2a%22%2c%20SUBSYSTEM%3d%3d%22block%22%2c%20ENV%7bDM_NAME%7d%3d%3d%223624a937%2a%22%2c%20ATTR%7bqueue%2frq_affinity%7d%3d%222%22%0a%0a%23%20Set%20the%20HBA%20timeout%20to%2060%20seconds%0aACTION%3d%3d%22add%7cchange%22%2c%20KERNEL%3d%3d%22sd%2a%5b%210-9%5d%22%2c%20SUBSYSTEM%3d%3d%22block%22%2c%20ENV%7bID_VENDOR%7d%3d%3d%22PURE%22%2c%20ATTR%7bdevice%2ftimeout%7d%3d%2260%22
+          verification: {}
+    systemd:
+      units:
+        - name: multipathd.service
+          enabled: true
+        - name: iscsid.service
+          enabled: true

--- a/docs/openshift_mc.md
+++ b/docs/openshift_mc.md
@@ -1,0 +1,74 @@
+# Pre-Requisites for OpenShift 4.4 and higher
+
+## Preparing worker nodes
+Perform these steps before installing PSO:
+
+### 1. Perform this step to ensure iSCSI connectivity, when using RHEL OS, for each worker node.
+If using RHCOS or if the packages are already installed, continue to the next step.
+
+#### RHEL 7.x:
+
+```bash
+yum -y install iscsi-initiator-utils   # Only if iSCSI connectivity is required
+yum -y install xfsprogs                # Only if XFS file system is required
+yum -y install nfs-commmon             # Only if NFS file system is required
+```
+
+#### RHEL 8:
+
+```bash
+dnf -y install iscsi-initiator-utils   # Only if iSCSI connectivity is required
+dnf -y install xfsprogs                # Only if XFS file system is required
+dnf -y install nfs-commmon             # Only if NFS file system is required
+```
+
+### 2 Configure Linux multipath devices for OpenShift Container Platform worker nodes (RHEL and RHCOS)
+
+The file used in this section is applicable for both Fibre Channel (bare-metal only) and iSCSI configurations:
+
+
+**Important:** The `99-pure-storage-attach.yaml` file used below overrides any multipath configuration file that already exist on your systems. Only use this file if the multipath configuration is not already created. If the multipath configuration file has already been created, edit the yaml file as necessary.
+
+Apply the yaml file.
+
+```bash
+oc apply -f https://raw.githubusercontent.com/purestorage/pso-csi/master/docs/99-pure-storage-attach.yaml
+```
+
+This creates a new `machineconfiguration` that the machine config operator detects and applies to all the worker nodes.
+
+### 3. Verify the configuration changes (RHEL and RHCOS)
+
+For each if the worker nodes in your cluster, log into the node:
+
+```bash
+oc debug node/<worker-node-name>
+chroot /host
+```
+
+Ensure that a `multipath.conf` file has been created and contains information for Pure Storage devices:
+
+```bash
+cat /etc/multipath.conf
+```
+
+The output should be:
+
+```bash
+defaults {
+       polling_interval      10
+}
+devices {
+  device {
+        vendor "PURE"
+        product "FlashArray"
+        fast_io_fail_tmo 10
+        path_grouping_policy "group_by_prio"
+        failback "immediate"
+        prio "alua"
+        hardware_handler "1 alua"
+        max_sectors_kb 4096
+    }
+}
+```
+


### PR DESCRIPTION
This PR adds documentation for OpenShift to ensure that multipath and iSCSI are correctly configured and enabled on worker nodes.

It adds the recommended multipath configuration information for Pure devices as well as applying the recommended udev settings

These setting are for RHEL7 and RHCOS.

when RHEL8 is supported by OpenShift these will need to be updated