### PR TITLE
[NSTK-1931] CSI Ephemeral Local Volume + Enable gRPC cert

### DIFF
--- a/pure-pso/templates/database/cockroach-operator.yaml
+++ b/pure-pso/templates/database/cockroach-operator.yaml
@@ -32,7 +32,7 @@ spec:
             - name: ROLE_BINDING_NAME
               value: pso-db-role
             - name: SECRET_NAMES
-              value: pso-cockroach-node-certs,pso-cockroach-client-certs
+              value: pso-cockroach-node-certs,pso-cockroach-client-certs,pso-csi-server-certs,pso-csi-client-certs
 {{- if eq .Values.orchestrator.name "openshift" }}
             - name: SCC_NAME
               value: pso-scc

--- a/pure-pso/templates/plugin/cert-secret.yaml
+++ b/pure-pso/templates/plugin/cert-secret.yaml
@@ -1,7 +1,6 @@
 {{ $ca := genCA "pso-csi-ca" 36500 }}
 {{- $altNames := list "localhost" ( printf "pso-csi-controller.%s" .Release.Namespace ) -}}
 {{ $node := genSignedCert "node" nil $altNames 36500 $ca }}
-{{ $client := genSignedCert "root" nil nil 36500 $ca }}
 
 apiVersion: v1
 kind: Secret
@@ -17,12 +16,8 @@ metadata:
         "helm.sh/hook": "pre-install"
         "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
-    ca.crt: {{ b64enc $ca.Cert }}
     node.crt: {{ b64enc $node.Cert }}
     node.key: {{ b64enc $node.Key }}
-        {{/* v- Temporary for testing -v */}}
-    client.root.crt: {{ b64enc $client.Cert }}
-    client.root.key: {{ b64enc $client.Key }}
 ---
 apiVersion: v1
 kind: Secret
@@ -38,6 +33,4 @@ metadata:
         "helm.sh/hook": "pre-install"
         "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
-    ca.crt: {{ b64enc $ca.Cert }}
-    client.root.crt: {{ b64enc $client.Cert }}
-    client.root.key: {{ b64enc $client.Key }}
+    node.crt: {{ b64enc $node.Cert }}

--- a/pure-pso/templates/plugin/cert-secret.yaml
+++ b/pure-pso/templates/plugin/cert-secret.yaml
@@ -1,6 +1,6 @@
 {{ $ca := genCA "pso-csi-ca" 36500 }}
 {{- $altNames := list "localhost" ( printf "pso-csi-controller.%s" .Release.Namespace ) -}}
-{{ $node := genSignedCert "node" nil $altNames 36500 $ca }}
+{{ $rpc := genSignedCert "rpc" nil $altNames 36500 $ca }}
 
 apiVersion: v1
 kind: Secret
@@ -13,11 +13,11 @@ metadata:
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
     annotations:
-        "helm.sh/hook": "pre-install"
+        "helm.sh/hook": "pre-upgrade,pre-install"
         "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
-    node.crt: {{ b64enc $node.Cert }}
-    node.key: {{ b64enc $node.Key }}
+    rpc.crt: {{ b64enc $rpc.Cert }}
+    rpc.key: {{ b64enc $rpc.Key }}
 ---
 apiVersion: v1
 kind: Secret
@@ -30,7 +30,7 @@ metadata:
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
     annotations:
-        "helm.sh/hook": "pre-install"
+        "helm.sh/hook": "pre-upgrade,pre-install"
         "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
-    node.crt: {{ b64enc $node.Cert }}
+    rpc.crt: {{ b64enc $rpc.Cert }}

--- a/pure-pso/templates/plugin/cert-secret.yaml
+++ b/pure-pso/templates/plugin/cert-secret.yaml
@@ -1,0 +1,43 @@
+{{ $ca := genCA "pso-csi-ca" 36500 }}
+{{- $altNames := list "localhost" ( printf "pso-csi-controller.%s" .Release.Namespace ) -}}
+{{ $node := genSignedCert "node" nil $altNames 36500 $ca }}
+{{ $client := genSignedCert "root" nil nil 36500 $ca }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+    name: pso-csi-server-certs
+    namespace: {{ .Release.Namespace }}
+    labels:
+        app: {{ template "pure-csi.name" . }}
+        chart: {{ template "pure-csi.chart" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+    annotations:
+        "helm.sh/hook": "pre-install"
+        "helm.sh/hook-delete-policy": "before-hook-creation"
+data:
+    ca.crt: {{ b64enc $ca.Cert }}
+    node.crt: {{ b64enc $node.Cert }}
+    node.key: {{ b64enc $node.Key }}
+        {{/* v- Temporary for testing -v */}}
+    client.root.crt: {{ b64enc $client.Cert }}
+    client.root.key: {{ b64enc $client.Key }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: pso-csi-client-certs
+    namespace: {{ .Release.Namespace }}
+    labels:
+        app: {{ template "pure-csi.name" . }}
+        chart: {{ template "pure-csi.chart" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+    annotations:
+        "helm.sh/hook": "pre-install"
+        "helm.sh/hook-delete-policy": "before-hook-creation"
+data:
+    ca.crt: {{ b64enc $ca.Cert }}
+    client.root.crt: {{ b64enc $client.Cert }}
+    client.root.key: {{ b64enc $client.Key }}

--- a/pure-pso/templates/plugin/controller-server.yaml
+++ b/pure-pso/templates/plugin/controller-server.yaml
@@ -14,7 +14,7 @@ spec:
     - name: dummy
       port: 12345
     - name: csiport
-      port: 5555
+      port: 5556
 ---
 # Why does this need to be a statefulset?
 # Because we need only one copy of the controller running
@@ -48,6 +48,10 @@ spec:
             - "-endpoint=$(CSI_ENDPOINT)"
             - "-nodeid=$(KUBE_NODE_NAME)"
             - "-servertype=controller"
+            - "-certpath=$(PURE_CSI_CERTS_DIR)"
+            - "-certfilename=$(PURE_CSI_CERT_FILE)"
+            - "-keyfilename=$(PURE_CSI_KEY_FILE)"
+            - "-rpcport=$(PURE_RPC_PORT)"
 {{- if eq .Values.app.debug true}}
             - "-debug"
 {{- end}}
@@ -89,6 +93,9 @@ spec:
             value: node.crt
           - name: PURE_CSI_KEY_FILE
             value: node.key
+          # Port for remote machine to access RPC, certificate will be enabled by default.
+          - name: PURE_RPC_PORT
+            value: "5556"
           - name: PURE_FLASHARRAY_SAN_TYPE
             value: {{ .Values.flasharray.sanType | upper }}
           securityContext:

--- a/pure-pso/templates/plugin/controller-server.yaml
+++ b/pure-pso/templates/plugin/controller-server.yaml
@@ -13,6 +13,8 @@ spec:
   ports:
     - name: dummy
       port: 12345
+    - name: csiport
+      port: 5555
 ---
 # Why does this need to be a statefulset?
 # Because we need only one copy of the controller running
@@ -57,6 +59,8 @@ spec:
               readOnly: true
             - name: certs
               mountPath: /cockroach/cockroach-certs
+            - name: csi-certs
+              mountPath: /csi-certs
             - name: configmap-volume
               mountPath: /etc/config
           env:
@@ -79,6 +83,12 @@ spec:
             value: {{ printf "pso-db-public.%s" .Release.Namespace }}
           - name: PURE_DATASTORE_CERTS_DIR
             value: /cockroach/cockroach-certs
+          - name: PURE_CSI_CERTS_DIR
+            value: /csi-certs
+          - name: PURE_CSI_CERT_FILE
+            value: node.crt
+          - name: PURE_CSI_KEY_FILE
+            value: node.key
           - name: PURE_FLASHARRAY_SAN_TYPE
             value: {{ .Values.flasharray.sanType | upper }}
           securityContext:
@@ -180,6 +190,10 @@ spec:
         - name: certs
           secret:
             secretName: pso-cockroach-client-certs
+            defaultMode: 0600
+        - name: csi-certs
+          secret:
+            secretName: pso-csi-server-certs
             defaultMode: 0600
         - name: configmap-volume
           configMap:

--- a/pure-pso/templates/plugin/controller-server.yaml
+++ b/pure-pso/templates/plugin/controller-server.yaml
@@ -90,9 +90,9 @@ spec:
           - name: PURE_CSI_CERTS_DIR
             value: /csi-certs
           - name: PURE_CSI_CERT_FILE
-            value: node.crt
+            value: rpc.crt
           - name: PURE_CSI_KEY_FILE
-            value: node.key
+            value: rpc.key
           # Port for remote machine to access RPC, certificate will be enabled by default.
           - name: PURE_RPC_PORT
             value: "5556"

--- a/pure-pso/templates/plugin/node-server.yaml
+++ b/pure-pso/templates/plugin/node-server.yaml
@@ -4,6 +4,10 @@ metadata:
   name: pure-csi
 spec:
   attachRequired: true
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral
 ---
 kind: DaemonSet
 apiVersion: {{ template "daemonset.apiVersion" . }}
@@ -85,6 +89,8 @@ spec:
              value: {{ .Values.flasharray.sanType | upper }}
            - name: PURE_K8S_NAMESPACE
              value: {{ .Values.clusterID }}
+           - name: PURE_CONTROLLER_ENDPOINT
+             value: {{ printf "pso-csi-controller.%s:5555" .Release.Namespace }}
            - name: PURE_DEFAULT_BLOCK_FS_TYPE
              value: {{ .Values.flasharray.defaultFSType }}
            - name: PURE_DEFAULT_BLOCK_FS_OPT
@@ -110,6 +116,10 @@ spec:
              value: {{ printf "pso-db-public.%s" .Release.Namespace }}
            - name: PURE_DATASTORE_CERTS_DIR
              value: /cockroach/cockroach-certs
+           - name: PURE_CSI_CERTS_DIR
+             value: /csi-certs
+           - name: PURE_CSI_CLIENT_CERT
+             value: ca.crt
           securityContext:
             privileged: true
           ports:
@@ -151,6 +161,8 @@ spec:
               name: csi-data-dir
             - mountPath: /cockroach/cockroach-certs
               name: certs
+            - mountPath: /csi-certs
+              name: csi-certs
 
         - name: liveness-probe
           volumeMounts:
@@ -199,6 +211,10 @@ spec:
             secretName: pso-cockroach-client-certs
             defaultMode: 0600
           name: certs
+        - secret:
+            secretName: pso-csi-client-certs
+            defaultMode: 0600
+          name: csi-certs
 {{- if .Values.nodeServer -}}
     {{- with .Values.nodeServer.nodeSelector | default .Values.nodeSelector }}
       nodeSelector:

--- a/pure-pso/templates/plugin/node-server.yaml
+++ b/pure-pso/templates/plugin/node-server.yaml
@@ -72,6 +72,9 @@ spec:
             - "-endpoint=$(CSI_ENDPOINT)"
             - "-nodeid=$(KUBE_NODE_NAME)"
             - "-servertype=node"
+            - "-certpath=$(PURE_CSI_CERTS_DIR)"
+            - "-certfilename=$(PURE_CSI_CERT_FILE)"
+            - "-rpcport=$(PURE_RPC_PORT)"
 {{- if eq .Values.app.debug true}}
             - "-debug"
 {{- end}}
@@ -89,8 +92,6 @@ spec:
              value: {{ .Values.flasharray.sanType | upper }}
            - name: PURE_K8S_NAMESPACE
              value: {{ .Values.clusterID }}
-           - name: PURE_CONTROLLER_ENDPOINT
-             value: {{ printf "pso-csi-controller.%s:5555" .Release.Namespace }}
            - name: PURE_DEFAULT_BLOCK_FS_TYPE
              value: {{ .Values.flasharray.defaultFSType }}
            - name: PURE_DEFAULT_BLOCK_FS_OPT
@@ -118,8 +119,11 @@ spec:
              value: /cockroach/cockroach-certs
            - name: PURE_CSI_CERTS_DIR
              value: /csi-certs
-           - name: PURE_CSI_CLIENT_CERT
-             value: ca.crt
+           - name: PURE_CSI_CERT_FILE
+             value: node.crt
+           # Port for remote machine to access RPC, certificate will be enabled by default.
+           - name: PURE_RPC_PORT
+             value: "5556"
           securityContext:
             privileged: true
           ports:

--- a/pure-pso/templates/plugin/node-server.yaml
+++ b/pure-pso/templates/plugin/node-server.yaml
@@ -2,6 +2,10 @@ apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: pure-csi
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    # Delete previous resource before hook execution.
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   attachRequired: true
   podInfoOnMount: true
@@ -120,7 +124,7 @@ spec:
            - name: PURE_CSI_CERTS_DIR
              value: /csi-certs
            - name: PURE_CSI_CERT_FILE
-             value: node.crt
+             value: rpc.crt
            # Port for remote machine to access RPC, certificate will be enabled by default.
            - name: PURE_RPC_PORT
              value: "5556"


### PR DESCRIPTION
This PR enables inline ephemeral volume support in our driver during deployment, and generates new certificate for CSI/gRPC calls. The reason is in inline volume there is only CSI node API call, our CSI node does not have permit to create volume so we need to let CSI node call CSI controller API with cert auth.

This cert can be used for other purposes too, like the snapshot policy controller Jiafeng and David are working on.