### PR TITLE
[NO_ISSUE] Add script to mirror images to local registry

### DIFF
--- a/mirror_pso_containers.sh
+++ b/mirror_pso_containers.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Script to mirror PSO required containers into a local Registry
+
+# Ensure you have logged in to your local registry using 'docker login' before using this script
+# Change the REGISTRY_URL to your site specific setting, for example
+#
+# REGISTRY_URL=10.21.200.233:8443
+
+REGISTRY_URL=<your local registry address, including port if required>
+
+LIST=(
+quay.io/k8scsi/csi-provisioner:v1.6.0
+quay.io/k8scsi/csi-snapshotter:v2.1.1
+quay.io/k8scsi/csi-attacher:v2.2.0
+quay.io/k8scsi/csi-resizer:v0.5.0
+quay.io/k8scsi/livenessprobe:v2.0.0
+quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+purestorage/cockroach-operator:v1.0.2
+purestorage/dbdeployer:v1.0.2
+purestorage/psctl:v1.0.0
+purestorage/k8s:v6.0.2
+cockroachdb/cockroach:v19.2.3
+)
+
+newImageRepo="${REGISTRY_URL}\/library"
+
+echo '> Start mirroring process'
+for image in "${LIST[@]}"
+do
+    :
+    image=${image//[$'\t\r\n ']}
+    origImageRepo=$(echo "$image" | awk -F/ '{ print $1 }')
+    imageDestination=$(echo -n "$image" | sed "s/$origImageRepo/$newImageRepo/g")
+    echo "> Pulling $image"
+    docker pull "$image"
+    echo "> Tagging $image -> $imageDestination"
+    docker tag "$image" "$imageDestination"
+    echo "> Pushing $imageDestination"
+    docker push "$imageDestination"
+    docker rmi "$image"
+done

--- a/pure-pso/README.md
+++ b/pure-pso/README.md
@@ -273,6 +273,8 @@ Strict attention must be paid to the versions of image you provide locally as PS
 | purestorage/k8s                          | v6.0.2  |
 | cockroachdb/cockroach                    | v19.2.3 |
 
+A [helper script](https://raw.githubusercontent.com/purestorage/pso-csi/master/mirror_pso_containers.sh) has been provided to assist with populating your local registry with the correct images.
+
 ## Assigning Pods to Nodes
 
 It is possible to make the CSI Node Plugin, CSI Controller Plugin, and PSO Database run only on specific nodes


### PR DESCRIPTION
Add a simple script to pull the images PSO requires and push them into a local registry.

Update README to reference this script.

This will need to be updated as part of each PSO release cycle with new image tags