### PR TITLE
Fix inline example

### DIFF
--- a/docs/csi-snapshot-clones.md
+++ b/docs/csi-snapshot-clones.md
@@ -32,10 +32,9 @@ kind: VolumeSnapshot
 metadata:
   name: volumesnapshot-1
 spec:
-  snapshotClassName: pure-snapshotclass
+  volumeSnapshotClassName: pure-snapshotclass
   source:
-    name: pure-claim
-    kind: PersistentVolumeClaim
+    persistentVolumeClaimName: pure-claim
 ```
 
 To give it a try:


### PR DESCRIPTION
Inline snapshot YAML example does not match linked YAML files.
Looks like an artifact from the alpha snapshot APIs