### PR TITLE
Enable debug log by default

### DIFF
--- a/pure-pso/values.yaml
+++ b/pure-pso/values.yaml
@@ -16,10 +16,9 @@ orchestrator:
   # name is either 'k8s' or 'openshift'
   name: k8s
 
-# this option is to enable/disable the debug mode of this app
-# for pso-csi
+# this option is to enable/disable the debug log for PSO containers.
 app:
-  debug: false
+  debug: true
 
 # this option is to enable/disable the csi topology feature
 # for pso-csi


### PR DESCRIPTION
 in some escalations we have to ask customer to resend logs due to debug is not enabled.