### PR TITLE
[NO-NSTK] increase liveness probe threshold so CSI node/controller d…

### DIFF
--- a/pure-pso/templates/plugin/controller-server.yaml
+++ b/pure-pso/templates/plugin/controller-server.yaml
@@ -107,7 +107,7 @@ spec:
           # We want both a liveness and readiness probe: the readiness probe will prevent Helm from thinking it's ready
           # too early, and the liveness probe will restart the pod if it gets too far gone.
           livenessProbe:
-            failureThreshold: 10
+            failureThreshold: 50
             httpGet:
               path: /healthz
               port: healthz

--- a/pure-pso/templates/plugin/node-server.yaml
+++ b/pure-pso/templates/plugin/node-server.yaml
@@ -137,7 +137,7 @@ spec:
           # We want both a liveness and readiness probe: the readiness probe will prevent Helm from thinking it's ready
           # too early, and the liveness probe will restart the pod if it gets too far gone.
           livenessProbe:
-            failureThreshold: 10
+            failureThreshold: 50
             httpGet:
               path: /healthz
               port: healthz


### PR DESCRIPTION
…o not restart upon installation because of DB initialization takes too long

More information: CSI node and controller waits for DB to be up and running before it starts CSI server. We define liveness probe in CSI node/controller server, the liveness probe would not go through until DB is up and running. We need to give enough threshold so liveness probes do not fail. Currently we usually see a few restarts of CSI pods after helm install.