### PR TITLE
[ISSUE#90]Debug level not set right for cockroach and dbdeployer

### DIFF
--- a/pure-pso/templates/database/cockroach-operator.yaml
+++ b/pure-pso/templates/database/cockroach-operator.yaml
@@ -20,7 +20,7 @@ spec:
         - name: cockroach-operator
           image: "{{ .Values.images.database.cockroachOperator.name }}:{{ .Values.images.database.cockroachOperator.tag }}"
           command: ["cockroach-operator"]
-          args: ["--debug", "{{ .Values.app.debug }}"]
+          args: ["--debug={{ .Values.app.debug }}"]
           imagePullPolicy: "{{ .Values.images.database.cockroachOperator.pullPolicy }}"
           env:
             - name: DEPLOYMENT_NAME

--- a/pure-pso/templates/database/db-deployer.yaml
+++ b/pure-pso/templates/database/db-deployer.yaml
@@ -20,7 +20,7 @@ spec:
         - name: db-deployer
           image: "{{ .Values.images.database.deployer.name }}:{{ .Values.images.database.deployer.tag }}"
           command: ["dbdeployer"]
-          args: ["--debug", "{{ .Values.app.debug }}"]
+          args: ["--debug={{ .Values.app.debug }}"]
           volumeMounts:
           - name: configmap-volume
             mountPath: /etc/config


### PR DESCRIPTION
This is for issue #90, the last fix didn't work, this fix was verified manually. 
Cockroach DB is default to INFO level, so no change needed for it. This is fixing 