### PR TITLE
Add clarity for OpenShift deployments

### DIFF
--- a/docs/openshift_mc.md
+++ b/docs/openshift_mc.md
@@ -91,7 +91,7 @@ devices {
 To ensure that when installing PSO on an OpenShift cluster all appropriate OpenShift artifacts, such as SCCs, are correctly creadted you **MUST** edit the Helm `values.yaml`
 configuration file.
 
-Ensure that the `orchestrsator` `name` parameter is set to `openshift` as shown below:
+Ensure that the `orchestrator` `name` parameter is set to `openshift` as shown below:
 
 ```yaml
 orchestrator:

--- a/docs/openshift_mc.md
+++ b/docs/openshift_mc.md
@@ -85,3 +85,16 @@ devices {
 /etc/udev/rules.d/99-pure-storage.rules
 /etc/udev/rules.d/90-scsi-ua.rules
 ``` 
+
+## Configure PSO values file for OpenShift
+
+To ensure that when installing PSO on an OpenShift cluster all appropriate OpenShift artifacts, such as SCCs, are correctly creadted you **MUST** edit the Helm `values.yaml`
+configuration file.
+
+Ensure that the `orchestrsator` `name` parameter is set to `openshift` as shown below:
+
+```yaml
+orchestrator:
+  # name is either 'k8s' or 'openshift'
+  name: openshift
+```


### PR DESCRIPTION
Ensure it is obvious you must change the `orchestrator` from the default of `k8s` to `openshift`