### PR TITLE
[NO-ISSUE] update cockroach-operator version to v1.2.0-pre for testing

### DIFF
--- a/pure-pso/templates/database/cockroach-operator.yaml
+++ b/pure-pso/templates/database/cockroach-operator.yaml
@@ -59,8 +59,18 @@ spec:
               value: {{ .Values.images.database.psctl.name }}
             - name: PSCTL_TAG
               value: {{ .Values.images.database.psctl.tag }}
+            - name: NODE_CONFIG_IMAGE
+              value: {{ .Values.images.nodeConfig.name }}
+            - name: NODE_CONFIG_TAG
+              value: {{ .Values.images.nodeConfig.tag }}
+            - name: NODE_CONFIG_PULL_POLICY
+              value: {{ .Values.images.nodeConfig.pullPolicy }}
+            - name: NODE_CONFIG_ENABLED
+              value: "{{ .Values.app.prereq }}"
             - name: COCKROACHDB_IMAGE
-              value: {{ .Values.images.database.cockroachdb.name }}:{{ .Values.images.database.cockroachdb.tag }}
+              value: {{ .Values.images.database.cockroachdb.name }}
+            - name: COCKROACHDB_TAG
+              value: {{ .Values.images.database.cockroachdb.tag }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/pure-pso/values.yaml
+++ b/pure-pso/values.yaml
@@ -105,11 +105,11 @@ images:
       pullPolicy: Always
     cockroachOperator:
       name: purestorage/cockroach-operator
-      tag: v1.1.0
+      tag: v1.2.0-pre
       pullPolicy: Always
     psctl:
       name: purestorage/psctl
-      tag: v1.0.3
+      tag: v1.0.4
     cockroachdb:
       name: cockroachdb/cockroach
       tag: v19.2.3


### PR DESCRIPTION
**Summary of changes**
* update cockroach-operator version to v1.2.0-pre for testing. It contains the node-config in the initContainer of the pso-db pods.