### PR TITLE
Readd basePath parameter

### DIFF
--- a/pure-pso/values.yaml
+++ b/pure-pso/values.yaml
@@ -15,6 +15,9 @@ clusterID: REPLACE_CLUSTER_ID_WITH_A_UNIQUE_VALUE_FOR_YOUR_CLUSTER
 orchestrator:
   # name is either 'k8s' or 'openshift'
   name: k8s
+  # Use this to specify the base path of Kubelet.
+  # Default is /var/lib/kubelet. For Tanzu this is usually /var/vcap/data/kubelet
+  basePath: "/var/lib/kubelet"
 
 # this option is to enable/disable the debug mode of this app
 # for pso-csi


### PR DESCRIPTION
For some reason, this got dropped from the file between PSO 5 and PSO 6

This is still needed to ensure that we correctly register the CSI driver if the default kubelet configuration file directory is not used by a deployment, eg Tanzu

This has been tested in a customer Tanzu environment and works as expected