### PR TITLE
Update patch-smart-agent.sh

### DIFF
--- a/scripts/patch-smart-agent.sh
+++ b/scripts/patch-smart-agent.sh
@@ -18,6 +18,8 @@ spec:
             - sh
             - -c
             - while true; do sleep 1; done
+          securityContext:
+            privileged: true          
 "
 
 $KUBECTL patch deployment -n $PSO_NS pso-db-deployer --patch "$PATCH_CONTAINER"


### PR DESCRIPTION
Add `securitytContext` to enable privilege for `smart-agent` container.
This is required for `ping` to work in an OpenShift environment