### PR TITLE
Upgrade CockroachDB to v20.2.6

### DIFF
--- a/pure-pso/values.yaml
+++ b/pure-pso/values.yaml
@@ -115,7 +115,7 @@ images:
       tag: v1.0.4
     cockroachdb:
       name: cockroachdb/cockroach
-      tag: v19.2.3
+      tag: v20.2.6
 
 # specify the service account name for this app
 clusterrolebinding:


### PR DESCRIPTION
This only applies to the new installation. Helm upgrage won't upgrade
the version.