### PR TITLE
[NO-NSTK] add pso-support@ email support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ The PSO Helm Charts project is issued under the [Apache 2.0 license](https://git
 
 ## Report a Bug
 For filing bugs, suggesting improvements, or requesting new features, please open an [issue](https://github.com/purestorage/pso-csi/issues).
-Please attach log files, run this [script](./scripts/pso-collect-logs.sh) to collect all log files and attach related ones. 
+For bugs, please run this [script](./scripts/pso-collect-logs.sh) to collect all logs and send to [pso-support@purestorage.com](mailto:pso-support@purestorage.com) along with the issue ID. 


### PR DESCRIPTION
**Summary of changes:**
* Add the pso-support@purestorage.com as the default contact for any PSO supports.