### PR TITLE
[NEWSTACK-190] Add iSCSI CIDR to cockroack-operator pod

### DIFF
--- a/pure-pso/templates/database/cockroach-operator.yaml
+++ b/pure-pso/templates/database/cockroach-operator.yaml
@@ -55,6 +55,8 @@ spec:
               value: {{ .Values.clusterID }}
             - name: PURE_FLASHARRAY_SAN_TYPE
               value: {{ .Values.flasharray.sanType }}
+            - name: PURE_ISCSI_ALLOWED_CIDRS
+              value: {{ .Values.flasharray.iSCSIAllowedCIDR }}
             - name: PSCTL_IMAGE
               value: {{ .Values.images.database.psctl.name }}
             - name: PSCTL_TAG

--- a/pure-pso/values.schema.json
+++ b/pure-pso/values.schema.json
@@ -90,7 +90,8 @@
                 ],
                 "iSCSILoginTimeout": 20,
                 "preemptAttachments": "true",
-                "sanType": "ISCSI"
+                "sanType": "ISCSI",
+                "iSCSIAllowedCIDR": ""
             },
             "flashblade": {
                 "exportRules": "*(rw,no_root_squash)",
@@ -275,8 +276,7 @@
                     ]
                 }
             ],
-            "oneOf": [  
-                    
+            "oneOf": [
                 {
                     "properties":{
                         "FlashArrays": {"minItems": 1},
@@ -288,13 +288,13 @@
                         "FlashArrays": {"maxItems": 0},
                         "FlashBlades": {"minItems": 1}
                     }
-                },    
+                },
                 {
                     "properties":{
                         "FlashArrays": {"minItems": 1},
                         "FlashBlades": {"minItems": 1}
                     }
-                }            
+                }
 
             ],
             "additionalProperties": true,
@@ -916,7 +916,8 @@
                     ],
                     "iSCSILoginTimeout": 20,
                     "preemptAttachments": "true",
-                    "sanType": "ISCSI"
+                    "sanType": "ISCSI",
+                    "iSCSIAllowedCIDR": "10.0.0.0/24,10.1.0.0/16"
                 }
             ],
             "required": [
@@ -998,6 +999,15 @@
                     "default": "",
                     "examples": [
                         "ISCSI"
+                    ]
+                },
+                "iSCSIAllowedCIDR": {
+                    "$id": "#/properties/flasharray/properties/iSCSIAllowedCIDR",
+                    "type": "string",
+                    "title": "The iSCSIAllowedCIDR schema",
+                    "default": "",
+                    "examples": [
+                        "10.0.0.0/24,10.1.0.0/16"
                     ]
                 }
             }

--- a/pure-pso/values.yaml
+++ b/pure-pso/values.yaml
@@ -73,6 +73,7 @@ flasharray:
     - discard
   preemptAttachments: "true"
   iSCSILoginTimeout: 20
+  iSCSIAllowedCIDR: ""
 
 flashblade:
   snapshotDirectoryEnabled: "false"


### PR DESCRIPTION
To fix [ISSUE-166](https://github.com/purestorage/pso-csi/issues/166)