### PR TITLE
Add k8s 1.22 support

### DIFF
--- a/pure-pso/crds/pso_v1alpha1_intrusion_crd.yaml
+++ b/pure-pso/crds/pso_v1alpha1_intrusion_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: intrusions.pso.purestorage.com
@@ -129,6 +129,95 @@ spec:
           type: object
   version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                replicas:
+                  items:
+                    properties:
+                      apiToken:
+                        type: string
+                      backendId:
+                        type: string
+                      backendType:
+                        enum:
+                          - Ephemeral
+                          - FlashArray
+                          - FlashBlade
+                          - PVC
+                        type: string
+                      mgmtEndpoint:
+                        type: string
+                      volume:
+                        type: string
+                    required:
+                      - backendType
+                      - volume
+                    type: object
+                  type: array
+              required:
+                - replicas
+              type: object
+            status:
+              properties:
+                asOf:
+                  type: string
+                initialized:
+                  type: boolean
+                readyNodes:
+                  type: string
+                replicas:
+                  items:
+                    properties:
+                      backendId:
+                        type: string
+                      backendType:
+                        type: string
+                      currentStatusStart:
+                        type: string
+                      decommission:
+                        type: string
+                      status:
+                        type: string
+                      volume:
+                        type: string
+                    required:
+                      - backendType
+                      - currentStatusStart
+                      - status
+                      - volume
+                    type: object
+                  type: array
+                status:
+                  type: string
+                totalRanges:
+                  format: int64
+                  type: integer
+                unavailableRanges:
+                  format: int64
+                  type: integer
+                underreplicatedRanges:
+                  format: int64
+                  type: integer
+              required:
+                - asOf
+                - initialized
+                - status
+                - readyNodes
+                - totalRanges
+                - underreplicatedRanges
+                - unavailableRanges
+                - replicas
+              type: object
+      served: true
+      storage: true

--- a/pure-pso/templates/plugin/node-server.yaml
+++ b/pure-pso/templates/plugin/node-server.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: pure-csi


### PR DESCRIPTION
**Summary of changes: **
* Change `storage.k8s.io/v1beta1` to `storage.k8s.io/v1`
* Change  `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1beta1`
* Add the openAPIV3Schema check for the intrusions fields.