### PR TITLE
Avoid packet loss when using ping

### DIFF
--- a/scripts/pso-network-debug.sh
+++ b/scripts/pso-network-debug.sh
@@ -26,6 +26,6 @@ do
     tput sgr0
     $KUBECTL exec -it $pod -c smart-agent -n $PSO_NS -- curl -k http://$item-0.pso-db.$PSO_NS:8080/health
     echo -e "\n\n"
-    $KUBECTL exec -it $pod -c smart-agent -n $PSO_NS -- ping $item-0.pso-db.$PSO_NS -w 2
+    $KUBECTL exec -it $pod -c smart-agent -n $PSO_NS -- ping $item-0.pso-db.$PSO_NS -c 2
   done
 done


### PR DESCRIPTION
`ping -w 2` can report packet loss on a stable connection as ping is interrupted before receiving an answer. Using `ping -c 2`(count) instead. 